### PR TITLE
Fix issue #227 (font-style in style-osx.css)

### DIFF
--- a/gitg/resources/ui/style-osx.css
+++ b/gitg/resources/ui/style-osx.css
@@ -1,5 +1,5 @@
 /* osx css styles */
 
 .monospace {
-	font: menlo;
+	font-family: menlo;
 }


### PR DESCRIPTION
Issue #227 (https://gitlab.gnome.org/GNOME/gitg/-/issues/227) seems to have been forgotten. This small patch fixes the annoying warning on MacOS.